### PR TITLE
Potential fix for code scanning alert no. 1: Incomplete URL substring sanitization

### DIFF
--- a/app/src/components/clubs/clubs.tsx
+++ b/app/src/components/clubs/clubs.tsx
@@ -11,9 +11,12 @@ const ClubShowcase: React.FC = () => {
   const isLinkedIn = (url: string) => {
     try {
       const parsedUrl = new URL(url);
-      return parsedUrl.host === "linkedin.com" || parsedUrl.host.endsWith(".linkedin.com");
-    } catch (e) {
-      return false; // Return false if the URL is invalid
+      return (
+        parsedUrl.host === "linkedin.com" ||
+        parsedUrl.host.endsWith(".linkedin.com")
+      );
+    } catch {
+      return false;
     }
   };
 

--- a/app/src/components/clubs/clubs.tsx
+++ b/app/src/components/clubs/clubs.tsx
@@ -8,7 +8,14 @@ import styles from "./clubs.module.css";
 import Card from "../ui/card/card";
 
 const ClubShowcase: React.FC = () => {
-  const isLinkedIn = (url: string) => url.includes("linkedin.com");
+  const isLinkedIn = (url: string) => {
+    try {
+      const parsedUrl = new URL(url);
+      return parsedUrl.host === "linkedin.com" || parsedUrl.host.endsWith(".linkedin.com");
+    } catch (e) {
+      return false; // Return false if the URL is invalid
+    }
+  };
 
   return (
     <div className={styles.container} id="clubs">


### PR DESCRIPTION
Potential fix for [https://github.com/upayanmazumder/upayan.dev/security/code-scanning/1](https://github.com/upayanmazumder/upayan.dev/security/code-scanning/1)

To fix the issue, we need to parse the URL and check its host explicitly to ensure it matches `linkedin.com` or its subdomains. This can be done using the `URL` constructor, which provides a reliable way to extract the host from a URL string. The `isLinkedIn` function will be updated to parse the URL and verify that the host ends with `.linkedin.com` or is exactly `linkedin.com`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
