### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/Versioning.yml
+++ b/.github/workflows/Versioning.yml
@@ -1,4 +1,6 @@
 name: Update package.json Version on Release
+permissions:
+  contents: write
 
 on:
   release:


### PR DESCRIPTION
Potential fix for [https://github.com/upayanmazumder/upayan.dev/security/code-scanning/2](https://github.com/upayanmazumder/upayan.dev/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly define the minimum permissions required. This workflow needs `contents: write` to update and commit changes to `package.json` and `package-lock.json`. By specifying this, we ensure that the workflow has only the permissions it needs and no more.

The `permissions` block will be added at the root level of the workflow, just below the `name` field, so it applies to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
